### PR TITLE
Fix setting default vals for Enums

### DIFF
--- a/compiler/src/main/cpp/capnpc-java.c++
+++ b/compiler/src/main/cpp/capnpc-java.c++
@@ -1007,7 +1007,7 @@ private:
             spaces(indent), "  public final void set", titleCase, "(", readerType, " value) {\n",
             unionDiscrim.set,
             (typeBody.which() == schema::Type::ENUM ?
-             kj::strTree(spaces(indent), "    _setShortField(", offset, ", (short)value.ordinal());\n") :
+             kj::strTree(spaces(indent), "    _setShortField(", offset, ", (short)value.ordinal()", defaultMaskParam, ");\n") :
              (typeBody.which() == schema::Type::VOID ?
               kj::strTree() :
               kj::strTree(spaces(indent), "    _set",

--- a/compiler/src/test/scala/org/capnproto/EncodingTest.scala
+++ b/compiler/src/test/scala/org/capnproto/EncodingTest.scala
@@ -221,6 +221,8 @@ class EncodingSuite extends FunSuite {
     val defaults = message.initRoot(TestDefaults.factory);
     TestUtil.checkDefaultMessage(defaults);
     TestUtil.checkDefaultMessage(defaults.asReader());
+    TestUtil.setDefaultMessage(defaults);
+    TestUtil.checkSettedDefaultMessage(defaults.asReader());
   }
 
   test("Groups") {

--- a/compiler/src/test/scala/org/capnproto/TestUtil.scala
+++ b/compiler/src/test/scala/org/capnproto/TestUtil.scala
@@ -21,6 +21,7 @@
 
 package org.capnproto;
 
+import org.capnproto.Text.Reader
 import org.scalatest.Matchers._;
 import org.capnproto.test.Test._;
 
@@ -280,6 +281,8 @@ object TestUtil {
     assert(builder.getUInt64Field() == 0xab54a98ceb1f0ad2L);
     assert(builder.getFloat32Field() == 1234.5f);
     assert(builder.getFloat64Field() == -123e45);
+    assert(builder.getEnumField() == TestEnum.CORGE);
+
     (builder.getTextField().toString()) should equal ("foo");
     (builder.getDataField().toArray()) should equal (Array(0x62,0x61,0x72));
   }
@@ -337,4 +340,35 @@ object TestUtil {
 
   }
 
+
+  def setDefaultMessage(builder : TestDefaults.Builder) {
+    builder.setBoolField(false);
+    builder.setInt8Field(-122);
+    builder.setInt16Field(-12344);
+    builder.setInt32Field(-12345677);
+    builder.setInt64Field(-123456789012344L);
+    builder.setUInt8Field(0xe9.toByte);
+    builder.setUInt16Field(45677.toShort);
+    builder.setUInt32Field(0xce0a6a13);
+    builder.setUInt64Field(0xab54a98ceb1f0ad1L);
+    builder.setFloat32Field(1234.4f);
+    builder.setFloat64Field(-123e44);
+    builder.setTextField(new Reader("bar"));
+    builder.setEnumField(TestEnum.QUX);
+  }
+
+  def checkSettedDefaultMessage(reader : TestDefaults.Reader) {
+    assert(reader.getBoolField() == false);
+    assert(reader.getInt8Field() == -122);
+    assert(reader.getInt16Field() == -12344);
+    assert(reader.getInt32Field() == -12345677);
+    assert(reader.getInt64Field() == -123456789012344L);
+    assert(reader.getUInt8Field() == 0xe9.toByte);
+    assert(reader.getUInt16Field() == 45677.toShort);
+    assert(reader.getUInt32Field() == 0xce0a6a13);
+    assert(reader.getUInt64Field() == 0xab54a98ceb1f0ad1L);
+    assert(reader.getFloat32Field() == 1234.4f);
+    assert(reader.getFloat64Field() == -123e44);
+    assert(reader.getEnumField() == TestEnum.QUX)
+  }
 }


### PR DESCRIPTION
Currently since we are xoring the default value in
the enums, if a enum field is set and then queries
you will encouter wrong values being returned. Adding
the xor offset in the generated code fixes this. Also
added a small test for this check